### PR TITLE
Avoid generation-time error if Peace Mod installed.

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -209,6 +209,12 @@ local function spawn_enemies_at_position(global_position)
 			end
 		end
 	end
+
+	-- avoid crashing if Peace Mod is installed
+	if not global.to_enemies.generation_size then
+		logger:log("Peace Mod (or similar) detected, not spawning enemies")
+		return
+	end
 	
 	-- make sure we do not spawn anything in the starting area
 	if 	global_position.x > global.enemy_protection_zone.x_min and


### PR DESCRIPTION
Without this, it crashes on line 185 and won't let you proceed, because `generation_size` is null.